### PR TITLE
Added getInitialSearchItem method

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,21 @@ SpotlightSearch.deleteAllItems().then(() => {
 
 ### Handling User Interactions
 
-Optionally, you can choose to add a custom handler that will be invoked in the event of a user tapping one of the search items in the Spotlight results:
+You can choose to add a custom handler that will be invoked in the event of a user tapping one of the search items in the Spotlight results:
 
 ```
 SpotlightSearch.searchItemTapped((uniqueIdentifier) => {
   alert(`You tapped on ${uniqueIdentifier}!`);
 });
+```
+
+Optionally, if you want to capture the search item that was tapped to open the app (perhaps the listener was set after the event was triggered):
+
+```
+SpotlightSearch.getInitialSearchItem().then((uniqueIdentifier) => {
+  alert(`You tapped on ${uniqueIdentifier} and opened the app!`);
+});
+
 ```
 
 The parameter will be the ```uniqueIdentifier``` that the item was indexed with. You can use this to lookup the item and display information about it, e.g. by navigating to a relevant page in your app.

--- a/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
+++ b/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
@@ -27,6 +27,8 @@ static NSString *const kSpotlightSearchItemTapped = @"spotlightSearchItemTapped"
 
 RCT_EXPORT_MODULE();
 
+static NSString* initialIdentifier;
+
 @synthesize bridge = _bridge;
 
 - (instancetype)init {
@@ -101,8 +103,14 @@ RCT_EXPORT_MODULE();
     if (!uniqueItemIdentifier) {
         return;
     }
+
+    initialIdentifier = uniqueItemIdentifier;
     
     [self sendEventWithName:kSpotlightSearchItemTapped body:uniqueItemIdentifier];
+}
+
+RCT_EXPORT_METHOD(getInitialSearchItem:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(initialIdentifier);
 }
 
 RCT_EXPORT_METHOD(indexItem:(NSDictionary *)item resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
Allows developer to capture the uniqueIdentifier of a search element that was tapped to open the app if the searchItemTapped event is omitted before the listener is in place.