### PR TITLE
Fix getInitialSearchItem code flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 \.DS_Store
 
-plugin/build 
+plugin/build
+.idea

--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ Optionally, if you want to capture the search item that was tapped to open the a
 SpotlightSearch.getInitialSearchItem().then((uniqueIdentifier) => {
   alert(`You tapped on ${uniqueIdentifier} and opened the app!`);
 });
+
+// example in a useEffect with listener cleanup
+useEffect(() => {
+    const spotlightListener = SpotlightSearch.searchItemTapped((uniqueIdentifier) => {
+        alert(`You tapped on ${uniqueIdentifier} and opened the app!`);
+    })
+    return () => {
+        // cleanup listener
+        spotlightListener.remove()
+    }
+}, [])
 ```
 
 The parameter will be the `uniqueIdentifier` that the item was indexed with. You can use this to lookup the item and display information about it, e.g. by navigating to a relevant page in your app.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { NativeEventSubscription } from 'react-native'
+
 type SpotlightItem = {
     title: string
     contentDescription?: string
@@ -18,6 +20,6 @@ export function deleteItemsInDomains(itemDomains: string[]): Promise<void>;
 
 export function deleteAllItems(): Promise<void>
 
-export function searchItemTapped(callback: (uniqueIdentifier: string) => void): void;
+export function searchItemTapped(callback: (uniqueIdentifier: string) => void): NativeEventSubscription;
 
 export function getInitialSearchItem(): Promise<string>

--- a/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
+++ b/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
@@ -15,17 +15,18 @@
 static NSString *const kHandleContinueUserActivityNotification = @"handleContinueUserActivity";
 static NSString *const kUserActivityKey = @"userActivity";
 static NSString *const kSpotlightSearchItemTapped = @"spotlightSearchItemTapped";
+static NSString * initialIdentifier = @"";
 
 @interface RCTSpotlightSearch ()
 
 @property (nonatomic, strong) id<NSObject> continueUserActivityObserver;
 @property (nonatomic, strong) id<NSObject> bundleDidLoadObserver;
-@property (nonatomic, copy) NSString *initialIdentifier;
 @property (nonatomic, assign) BOOL hasListeners;
 
 @end
 
 @implementation RCTSpotlightSearch
+static NSString *initialIdentifier;
 
 RCT_EXPORT_MODULE();
 
@@ -112,7 +113,7 @@ RCT_EXPORT_MODULE();
         return;
     }
 
-    self.initialIdentifier = uniqueItemIdentifier;
+    initialIdentifier = uniqueItemIdentifier;
     
     if (!self.hasListeners) {
         return;
@@ -122,7 +123,7 @@ RCT_EXPORT_MODULE();
 }
 
 RCT_EXPORT_METHOD(getInitialSearchItem:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    resolve(self.initialIdentifier);
+    resolve(initialIdentifier);
 }
 
 RCT_EXPORT_METHOD(indexItem:(NSDictionary *)item resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
Fix getInitialSearchItem where it is null when opening the app from a cold start state (not backgrounded). This sets the initialIdentifier as a static property shared among instances. This also fixes the typescript interface to add the NativeEventSubscription as the return value on the getInitialSearchItem function along with a README example.