### PR TITLE
Support appDelegate being cpp

### DIFF
--- a/plugin/src/withSpotlight.ts
+++ b/plugin/src/withSpotlight.ts
@@ -28,7 +28,7 @@ const modifyAppDelegate = (appDelegate: string) => {
 
 const withSpotlightAppDelegate = (config: any) => {
   return withAppDelegate(config, (config) => {
-    if (config.modResults.language === "objc") {
+    if (['objc', 'objcpp'].includes(config.modResults.language)) {
       config.modResults.contents = modifyAppDelegate(
         config.modResults.contents
       );


### PR DESCRIPTION
This PR adds support for c++-based appDelegates (which is the case for Expo for example).