### PR TITLE
Adding 'search in app' functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,3 +23,5 @@ export function deleteAllItems(): Promise<void>
 export function searchItemTapped(callback: (uniqueIdentifier: string) => void): NativeEventSubscription;
 
 export function getInitialSearchItem(): Promise<string>
+
+export function searchInApp(callback: (query: string) => void): NativeEventSubscription;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const {SpotlightSearch} = NativeModules;
 const spotlightEventEmitter = new NativeEventEmitter(SpotlightSearch);
 
 const EVENT_ITEM_TAPPED = 'spotlightSearchItemTapped';
+const SEARCH_IN_APP = 'spotlightSearchInApp';
 const nullFunc = () => {};
 
 export default {
@@ -33,6 +34,10 @@ export default {
     }),
     searchItemTapped: Platform.select({
         ios: (callback) => spotlightEventEmitter?.addListener(EVENT_ITEM_TAPPED, callback),
+        android: nullFunc
+    }),
+    searchInApp: Platform.select({
+        ios: (callback) => spotlightEventEmitter?.addListener(SEARCH_IN_APP, callback),
         android: nullFunc
     }),
 }

--- a/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
+++ b/ios/RCTSpotlightSearch/RCTSpotlightSearch/RCTSpotlightSearch.m
@@ -15,6 +15,7 @@
 static NSString *const kHandleContinueUserActivityNotification = @"handleContinueUserActivity";
 static NSString *const kUserActivityKey = @"userActivity";
 static NSString *const kSpotlightSearchItemTapped = @"spotlightSearchItemTapped";
+static NSString *const kSpotlightSearchInApp = @"spotlightSearchInApp";
 static NSString * initialIdentifier = @"";
 
 @interface RCTSpotlightSearch ()
@@ -63,7 +64,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[kSpotlightSearchItemTapped];
+    return @[kSpotlightSearchItemTapped, kSpotlightSearchInApp];
 }
 
 - (dispatch_queue_t)methodQueue {
@@ -108,18 +109,19 @@ RCT_EXPORT_MODULE();
 
 - (void)handleContinueUserActivity:(NSUserActivity *)userActivity {
     NSString *uniqueItemIdentifier = userActivity.userInfo[CSSearchableItemActivityIdentifier];
+    NSString *query = userActivity.userInfo[CSSearchQueryString];
     
-    if (!uniqueItemIdentifier) {
-        return;
-    }
-
-    initialIdentifier = uniqueItemIdentifier;
-    
-    if (!self.hasListeners) {
+    if (!self.hasListeners || (!uniqueItemIdentifier && !query)) {
         return;
     }
     
-    [self sendEventWithName:kSpotlightSearchItemTapped body:uniqueItemIdentifier];
+    if (uniqueItemIdentifier) {
+        initialIdentifier = uniqueItemIdentifier;
+        [self sendEventWithName:kSpotlightSearchItemTapped body:uniqueItemIdentifier];
+    } else if (query) {
+        initialIdentifier = query;
+        [self sendEventWithName:kSpotlightSearchInApp body:query];
+    }
 }
 
 RCT_EXPORT_METHOD(getInitialSearchItem:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
This adds a new method, `searchInApp`, which is triggered when users tap the 'Search in app' button in Spotlight and captures the query string users typed into Spotlight search and passes it along to the app. 